### PR TITLE
Only enable tab tracking in edit mode

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,6 +1,6 @@
 <Navbar isLoggedIn={$isAuthenticated} {isApp} />
 <main>
-  {#if !isPwa()}
+  {#if !isPwa() && isApp && $isAuthenticated}
     <MultipleTabs />
   {/if}
   <Flash />

--- a/client/src/MultipleTabs.svelte
+++ b/client/src/MultipleTabs.svelte
@@ -9,7 +9,7 @@
   import { create, read, erase } from './cookie'
   import Dialog from './Dialog.svelte'
 
-  let tabs =  parseInt(read('dont-do-tabs') || 0)
+  let tabs = parseInt(read('dont-do-tabs') || 0)
   tabs += 1
 
   create('dont-do-tabs', tabs)


### PR DESCRIPTION
With the new landing page we can't assume to always be in edit mode anymore. We now also exclude the tracking when the user is not authenticated (i.e. on the login / register pages).