### PR TITLE
Focus title on new note

### DIFF
--- a/client/src/NoteEdit.svelte
+++ b/client/src/NoteEdit.svelte
@@ -124,7 +124,7 @@
     autoSave.startPolling()
 
     noteNewSubscription = EventHive.subscribe('note.new', (data) => {
-      setNewNote()
+      setNewNote(() => note = new Note())
     })
 
     await tick()
@@ -200,7 +200,7 @@
   }
 
   const handleNewNoteClicked = () => {
-    setNewNote()
+    setNewNote(() => note = new Note())
   }
 
   const handleShowListClicked = () => {


### PR DESCRIPTION
When clicking "+" or using the keyboard shortcut to create a new note the code that sets the focus wasn't triggered anymore in case the current note was already a new note. The note didn't change, and so the focus code assumed to not do anything. By instantiating a new note we now force focusing on the title.