### PR TITLE
Add tooltips to icon actions

### DIFF
--- a/client/src/ActionBar.svelte
+++ b/client/src/ActionBar.svelte
@@ -5,7 +5,7 @@
 
   <SaveStateLabel {isSynced} />
 
-  <button name="new" on:click={() => dispatch('newClicked')} class="icon big">
+  <button name="new" data-tooltip="Create note" on:click={() => dispatch('newClicked')} class="icon big tooltip-top-left">
     <NewIcon />
   </button>
 </div>

--- a/client/src/App.sass
+++ b/client/src/App.sass
@@ -58,9 +58,6 @@ input
 .icon
   @include icon
 
-  &.full-width
-    width: 100% !important
-
   &.left-aligned
     @include icon
 
@@ -110,3 +107,60 @@ button.pseudo.icon-lg
 .collapsed
   height: 0
   overflow: hidden
+
+// picnic tooltip overwrite / extension
+button[data-tooltip]
+  transition: none
+
+[data-tooltip]
+  &:after,
+  &:before
+    z-index: 10000
+    transition: opacity .6s ease, height 0s ease .6s, z-index 0s
+
+  &:after
+    background-color: $picnic-black !important
+
+  // disable tooltips for devices not supporting hover (i.e. touch devices)
+  @media (hover: none)
+    &:hover:after,
+    &:focus:after,
+    &:hover:before,
+    &:focus:before
+      opacity: 0
+      border-width: 0
+      height: 0
+      padding: 0
+
+.tooltip-top-left
+  &:after,
+  &:before
+    top: auto
+    bottom: calc(100% - 6px)
+    left: auto
+    right: 100%
+    margin-bottom: 12px
+    margin-right: -26px
+
+  &:before
+    border-color: $picnic-tooltip-background transparent transparent
+    left: auto
+    right: 100%
+    margin-bottom: 0
+    margin-right: -18px
+
+.tooltip-top-right
+  &:after,
+  &:before
+    top: auto
+    bottom: calc(100% - 6px)
+    left: 100%
+    margin-left: -23px
+    margin-bottom: 12px
+
+  &:before
+    border-color: $picnic-tooltip-background transparent transparent
+    left: 100%
+    right: auto
+    margin-bottom: 0
+    margin-left: -15px

--- a/client/src/LoadMoreButton.svelte
+++ b/client/src/LoadMoreButton.svelte
@@ -1,11 +1,11 @@
 {#if showLoadMoreButton && !showSpinner}
-  <button name="load-more" class='icon big full-width' on:click={handleLoadMoreClick}>
+  <button name="load-more" class='icon big center tooltip-top-left' data-tooltip="Load more notes" on:click={handleLoadMoreClick}>
     <MoreIcon />
   </button>
 {/if}
 
 {#if showSpinner}
-  <div class="icon big full-width">
+  <div class="icon big center">
     <Spinner />
   </div>
 {/if}
@@ -27,3 +27,9 @@
     dispatch('loadMore')
   }
 </script>
+
+<style lang="sass">
+  .center
+    display: block
+    margin: auto
+</style>

--- a/client/src/Logout.svelte
+++ b/client/src/Logout.svelte
@@ -1,4 +1,4 @@
-<button name="logout" on:click={handleClicked} class="icon-lg big pseudo logout" title="Logout">
+<button name="logout" on:click={handleClicked} class="icon-lg big pseudo logout tooltip-left" data-tooltip="Logout">
   <LogoutIcon />
   <span class="icon-lg-text">Logout</span>
 </button>

--- a/client/src/NoteList.svelte
+++ b/client/src/NoteList.svelte
@@ -31,13 +31,13 @@
           </div>
         </div>
         <div class="list-item-actions">
-          <button name="archive-note" class='icon' on:click={event => {
+          <button name="archive-note" class='icon tooltip-top-left' data-tooltip="Archive note" on:click={event => {
                 event.stopPropagation()
                 dispatch('archiveNote', note)
               }}>
             <ArchiveIcon />
           </button>
-          <button name="delete-note" class='icon' on:click={event => {
+          <button name="delete-note" class='icon tooltip-top-left' data-tooltip="Delete note" on:click={event => {
               event.stopPropagation()
               dispatch('deleteNote', note)
             }}>
@@ -173,6 +173,8 @@
     align-items: center
     justify-content: space-between
     padding: 0 $picnic-separation
+    // needed for tooltip to be able to overflow
+    overflow: visible
 
     &.active
       color: $picnic-primary

--- a/client/src/TaskGroup.svelte
+++ b/client/src/TaskGroup.svelte
@@ -19,7 +19,7 @@
   <div>
     {#if done.length > 0}
       <footer>
-        <button name="toggle-done" class='icon left-aligned full-width' on:click={() => (showDone = !showDone)}>
+        <button name="toggle-done" class='icon left-aligned tooltip-top-right' data-tooltip="Show completed" on:click={() => (showDone = !showDone)}>
           {#if showDone}
             <LessIcon />
           {:else}


### PR DESCRIPTION
The icons may not be self explanatory enough. Having a tooltip may be nice.
I also added a custom picnic class for a top left position tooltip.

This patch also disables the tooltips on touch devices altogether, since

1. they only appear when the buttons are clicked, which is distracting and useless (it's already too late)
2. the styling looks a bit off (at least on chrome mobile), as there's a white line between the arrow and the box

![image](https://github.com/koffeinfrei/unnote/assets/176582/97f3e571-2ab2-441c-b6c3-5a8c998187e8)
