### PR TITLE
Remove gap for the tooltip between arrow and box

### DIFF
--- a/client/src/App.sass
+++ b/client/src/App.sass
@@ -109,6 +109,14 @@ button.pseudo.icon-lg
   overflow: hidden
 
 // picnic tooltip overwrite / extension
+.tooltip-top
+  &:before
+    margin-bottom: 1px
+
+.tooltip-left
+  &:before
+    margin-right: -5px
+
 button[data-tooltip]
   transition: none
 
@@ -146,7 +154,7 @@ button[data-tooltip]
     border-color: $picnic-tooltip-background transparent transparent
     left: auto
     right: 100%
-    margin-bottom: 0
+    margin-bottom: 1px
     margin-right: -18px
 
 .tooltip-top-right
@@ -162,5 +170,5 @@ button[data-tooltip]
     border-color: $picnic-tooltip-background transparent transparent
     left: 100%
     right: auto
-    margin-bottom: 0
+    margin-bottom: 1px
     margin-left: -15px


### PR DESCRIPTION
Between the arrow and the box there was a 1px gap. This used to be fine. I'm not sure if something in the newer browsers has changed to introduce this. The issue is in picnic already, not just our custom styles.

![image](https://github.com/koffeinfrei/unnote/assets/176582/0d9919f8-80f5-45be-ba42-6188b3d5d08c)
