### PR TITLE
Show default note images in list again

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     },
   },
   build: {
+    assetsInlineLimit: 0,
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),


### PR DESCRIPTION
With the recent npm packages update something broke related to imported images. In `NotePicture.svelte` the two images `noteDefault` and `taskDefault` would not be set as background images. In dev all is fine. The issue seems to be with the build process. After some debugging I decided to just disable inlining of images altogether, which fixes the current issue. I can't be bothered with this kind of stupid problems.