### PR TITLE
focus new title when search term is present

### DIFF
--- a/client/src/NoteForm.svelte
+++ b/client/src/NoteForm.svelte
@@ -67,7 +67,7 @@
   }
 
   const focusTitleFieldIfNewNote = () => {
-    if (note.isNew() && !$searchTerm) {
+    if (note.isNew()) {
       setTimeout(() => titleElement.focus(), 100)
     }
   }


### PR DESCRIPTION
This reverts 18fae1a6. I don't know which case that fix addressed. Let's revert for now, and come back to this once we see what it tried to solve. Overall though, the current bug where the title field doesn't focus when hitting alt+shift+n while there's a search term present is most annoying. Whatever that original patch tried to fix needs a better solution.