### PR TITLE
Remove timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,3 @@ group :development do
   gem 'rubocop-rspec', '~> 2.19', require: false
   gem 'seed_box'
 end
-
-group :test do
-  gem 'timecop'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,7 +370,6 @@ GEM
     stringio (3.1.0)
     strscan (3.1.0)
     thor (1.3.1)
-    timecop (0.9.9)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -421,7 +420,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-commands-rspec
-  timecop
   webrick
 
 BUNDLED WITH

--- a/spec/features/edit_note_conflict_spec.rb
+++ b/spec/features/edit_note_conflict_spec.rb
@@ -3,45 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe 'Edit note with conflict', :js do
+  include ActiveSupport::Testing::TimeHelpers
+
   context 'as logged in user' do
     let(:user) { create_user }
 
     before { login_as user }
 
     it 'A copy of the note is created' do
-      Timecop.travel(Time.zone.local(2016, 8, 1, 15, 33)) do
-        note = Note.create!(
-          title: 'my note',
-          user: user,
-          content: 'note content',
-          uid: SecureRandom.uuid
-        )
+      travel_to Time.zone.local(2016, 8, 1, 15, 33)
 
-        # load the note...
-        visit_and_wait "/#/notes/#{note.uid}"
-        expect(page).to have_content 'my note'
-        expect(page).to have_content 'note content'
+      note = Note.create!(
+        title: 'my note',
+        user: user,
+        content: 'note content',
+        uid: SecureRandom.uuid
+      )
 
-        # ...in the meantime there's an edit
-        note.update! content: '<p>note content - update 1</p>'
+      # load the note...
+      visit_and_wait "/#/notes/#{note.uid}"
+      expect(page).to have_content 'my note'
+      expect(page).to have_content 'note content'
 
-        find('.ql-editor').set('note content - update 2')
+      # ...in the meantime there's an edit
+      note.update! content: '<p>note content - update 1</p>'
 
-        after_save_cycle do
-          expect(page).to have_content 'SAVED'
-        end
+      find('.ql-editor').set('note content - update 2')
 
-        expect(page).to have_content 'my note (conflict 2016-08-01 15:33)'
-
-        # the note has the updated content
-        expect(note.reload.content).to eq '<p>note content - update 2</p>'
-
-        # the conflict copy has the old content
-        expect(Note.last).to have_attributes(
-          title: 'my note (conflict 2016-08-01 15:33)',
-          content: '<p>note content - update 1</p>'
-        )
+      after_save_cycle do
+        expect(page).to have_content 'SAVED'
       end
+
+      expect(page).to have_content 'my note (conflict 2016-08-01 15:33)'
+
+      # the note has the updated content
+      expect(note.reload.content).to eq '<p>note content - update 2</p>'
+
+      # the conflict copy has the old content
+      expect(Note.last).to have_attributes(
+        title: 'my note (conflict 2016-08-01 15:33)',
+        content: '<p>note content - update 1</p>'
+      )
     end
   end
 end

--- a/spec/features/edit_note_conflict_spec.rb
+++ b/spec/features/edit_note_conflict_spec.rb
@@ -26,22 +26,24 @@ RSpec.describe 'Edit note with conflict', :js do
       expect(page).to have_content 'note content'
 
       # ...in the meantime there's an edit
+      travel_to Time.zone.local(2016, 8, 1, 15, 34)
       note.update! content: '<p>note content - update 1</p>'
 
+      travel_to Time.zone.local(2016, 8, 1, 15, 35)
       find('.ql-editor').set('note content - update 2')
 
       after_save_cycle do
         expect(page).to have_content 'SAVED'
       end
 
-      expect(page).to have_content 'my note (conflict 2016-08-01 15:33)'
+      expect(page).to have_content 'my note (conflict 2016-08-01 15:35)'
 
       # the note has the updated content
       expect(note.reload.content).to eq '<p>note content - update 2</p>'
 
       # the conflict copy has the old content
       expect(Note.last).to have_attributes(
-        title: 'my note (conflict 2016-08-01 15:33)',
+        title: 'my note (conflict 2016-08-01 15:35)',
         content: '<p>note content - update 1</p>'
       )
     end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Note do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe '#as_json' do
     context 'when no options provided' do
       it 'returns the whitelisted attributes' do
@@ -120,16 +122,16 @@ RSpec.describe Note do
     it 'sets the archived_at timestamp' do
       now = Time.zone.local(2016, 8, 1, 15, 33)
 
-      Timecop.freeze(now) do
-        note = described_class.create!(
-          uid: SecureRandom.uuid,
-          user: create_user
-        )
+      travel_to now
 
-        note.archive!
+      note = described_class.create!(
+        uid: SecureRandom.uuid,
+        user: create_user
+      )
 
-        expect(note.archived_at).to eq now
-      end
+      note.archive!
+
+      expect(note.archived_at).to eq now
     end
   end
 


### PR DESCRIPTION
Rails has long been including its own
`ActiveSupport::Testing::TimeHelpers`, which makes the dependency on `timecop` obsolete.