### PR TITLE
use alternative fonts to roboto

### DIFF
--- a/client/src/stylesheets/_variables.scss
+++ b/client/src/stylesheets/_variables.scss
@@ -8,7 +8,7 @@ $picnic-success: #1da42d;
 
 @import 'picnic/src/themes/default/theme';
 
-$font-family: 'Roboto';
+$font-family: Roboto, Helvetica, Arial, Liberation Sans, Nimbus Sans, sans-serif;
 $font-size-sm: .75em;
 $font-size-md: .85em;
 $light-gray: #f9f9f9;


### PR DESCRIPTION
A longer while ago I removed the Roboto font-face css. Ever since Roboto only worked when the client had the font installed locally. Which probably weren't too many clients.

I'm not too keen on using custom fonts again. For now I'll just use some standard fonts and some applicable alternatives.

Fixes https://github.com/koffeinfrei/unnote/issues/733